### PR TITLE
Handle React resume upload and configure CORS

### DIFF
--- a/analyser/views.py
+++ b/analyser/views.py
@@ -38,24 +38,28 @@ def get_file_type(file_path):
         
 """Uploads a resume and extracts text from it."""
 def upload_resume(request):
-    uploaded_file = request.FILES['resume']
+    uploaded_file = request.FILES.get('resume') or request.FILES.get('file')
+    if not uploaded_file:
+        return None, "No resume file provided."
     
     fs = FileSystemStorage()
     filename = fs.save(uploaded_file.name, uploaded_file)
     file_path = fs.path(filename)
 
-    # Extract text from the PDF
     ext = get_file_type(file_path)
     if ext == 'pdf':
         extracted_text = extract_text_from_pdf(file_path)
     elif ext == 'docx':
         extracted_text = extract_text_from_doc(file_path)
     else:
-        return "Invalid file type"
-    return extracted_text
+        fs.delete(filename)
+        return None, "Invalid file type. Please upload a PDF or DOCX."
+
+    fs.delete(filename)
+    return extracted_text, None
 
 def parse_job_posting(request):
-        job_url = request.POST.get('job')
+        job_url = request.POST.get('job') or request.POST.get('job_url')
         job_data = parse_linkedin_job_posting(job_url)
         return job_data
     
@@ -65,7 +69,9 @@ def match_requirements(request):
     if request.method != "POST":
         return JsonResponse({"error": "Invalid request method"}, status=405)
     
-    resume_text = upload_resume(request)
+    resume_text, upload_error = upload_resume(request)
+    if upload_error:
+        return JsonResponse({"error": upload_error}, status=400)
     job_data = parse_job_posting(request)
 
     result = {
@@ -77,5 +83,4 @@ def match_requirements(request):
     }
 
     return JsonResponse(result)
-
 

--- a/resume_analyser/settings.py
+++ b/resume_analyser/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'django-insecure-7ea#t24#jrnhn#mh53*0=v6r_n)&-kwvv-z7avm5a&nw+rwn&b
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 
 # Application definition
@@ -45,12 +45,12 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware'
 ]
 
 ROOT_URLCONF = 'resume_analyser.urls'

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,10 +14,10 @@
         {% csrf_token %}
         <!-- Specifies the route to send the form data to -->
         <label for="resume">Upload your resume:</label>
-        <input type="file" id="resume" name="file" accept=".pdf,.docx" required>
+        <input type="file" id="resume" name="resume" accept=".pdf,.docx" required>
         
         <label for="job_url">Enter LinkedIn Job URL:</label>
-        <input type="url" id="job_url" name="job_url" required>
+        <input type="url" id="job_url" name="job" required>
         
         <button type="submit">Match</button>
     </form>


### PR DESCRIPTION
This pull request provides a small fix to address the issue with the react resume upload and the missing CORS configuration
- Updated the upload view to correctly handle the `resume` field with a fallback for `file`, return clearer 400 errors, and clean up temporary files after reading.
- Reordred the CORS middleware and added the proper allowed hosts so the frontend can reach the API.
- Updated `index.html` so its fields match the backend : `resume` / `job`

- Manual check using the React frontend: the upload now succeeds and returns the expected job information.
- The requesst is correctly received from `/match_requirements`, confirming that CORS is working.

Closes #7